### PR TITLE
Added support for variable UID and GID to match mount volume permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.9.4
+FROM amd64/alpine:latest
 
-MAINTAINER Logan HAUSPIE <logan.hauspie.pro@gmail.com>
+MAINTAINER Matt Fiscus <m@fisc.us>
 LABEL Description="vsftpd Docker image based on Alpine. Supports passive mode and virtual users." \
 	License="GNU General Public License v3" \
 	Usage="docker run --rm -it --name vsftpd -p [HOST_CONNECTION_PORTS]:20-22 -p [HOST_FTP_PORTS]:21100-21110 lhauspie/vsftpd-alpine" \

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
-VERSION ?= 1.0.0-SNAPSHOT
+VERSION ?= 1.0.0
 CONTAINER_NAME ?= vsftpd
 
 .PHONY: build
 build:
-	docker build . -t lhauspie/vsftpd-alpine -t lhauspie/vsftpd-alpine:${VERSION}
+	docker build . -t mfiscus/vsftpd-alpine:latest -t mfiscus/vsftpd-alpine:${VERSION}
 
 .PHONY: 
 push:
-	docker push lhauspie/vsftpd-alpine
+	docker push mfiscus/vsftpd-alpine
 
 
 .PHONY: run

--- a/run-vsftpd.sh
+++ b/run-vsftpd.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 # Define default values of Environment Variables
+FTP_UID=${FTP_UID:-431}
+FTP_GID=${FTP_GID:-433}
 FTP_USER=${FTP_USER:-user}
 FTP_PASS=${FTP_PASS:-pass}
 PASV_ENABLE=${PASV_ENABLE:-YES}
@@ -30,8 +32,8 @@ else
 fi
 
 # Add the FTP_USER, change his password and declare him as the owner of his home folder and all subfolders
-addgroup -g 433 -S $FTP_USER
-adduser -u 431 -D -G $FTP_USER -h /home/vsftpd/$FTP_USER -s /bin/false  $FTP_USER
+addgroup -g $FTP_GID -S $FTP_USER
+adduser -u $FTP_UID -D -G $FTP_USER -h /home/vsftpd -s /bin/false  $FTP_USER
 echo "$FTP_USER:$FTP_PASS" | /usr/sbin/chpasswd
 chown -R $FTP_USER:$FTP_USER /home/vsftpd/
 


### PR DESCRIPTION
It was necessary to specify the UID and GID within the docker-compose.yml so that the service could read/write from the mounted volume on the host filesystem. If the variable is not defined in docker-compose.yml, then the original default values of 431:433 are used.